### PR TITLE
优化页面加载逻辑

### DIFF
--- a/MJCSegmentInterface/MJCSegmentInterface.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MJCSegmentInterface/MJCSegmentInterface.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MJCSegmentInterface/MJCSegmentInterface/MJCSlideInterface/childs/MJCChildMainView.m
+++ b/MJCSegmentInterface/MJCSegmentInterface/MJCSlideInterface/childs/MJCChildMainView.m
@@ -88,10 +88,10 @@ static CGFloat const animalTime= 0.25;
         UIViewController *childVc;
         if (index >= _hostController.childViewControllers.count) {return;}
         childVc = _hostController.childViewControllers[index];
+        [self preloadNextControllerView:index];
         if ([childVc isViewLoaded] && [childVc.view window]) return;
         childVc.view.frame = self.bounds;
         [self addSubview:childVc.view];
-        [self preloadNextControllerView:index];
     }else{
         if (_childViewArray.count != 0) {
             NSUInteger index = self.contentOffset.x / self.jc_width;

--- a/MJCSegmentInterface/MJCSegmentInterface/MJCSlideInterface/childs/MJCChildMainView.m
+++ b/MJCSegmentInterface/MJCSegmentInterface/MJCSlideInterface/childs/MJCChildMainView.m
@@ -91,6 +91,7 @@ static CGFloat const animalTime= 0.25;
         if ([childVc isViewLoaded] && [childVc.view window]) return;
         childVc.view.frame = self.bounds;
         [self addSubview:childVc.view];
+        [self preloadNextControllerView:index];
     }else{
         if (_childViewArray.count != 0) {
             NSUInteger index = self.contentOffset.x / self.jc_width;
@@ -101,6 +102,26 @@ static CGFloat const animalTime= 0.25;
         }
     }
 }
+
+/**
+ 预加载选中页面左右两边页面
+ */
+- (void)preloadNextControllerView:(NSInteger)currentIndex {
+    NSInteger nextIndex = currentIndex + 1;
+    while (nextIndex > 0 && ABS(currentIndex - nextIndex <= 1)) {
+        if (nextIndex >= _hostController.childViewControllers.count) {
+            nextIndex = nextIndex - 2;
+            continue;
+        }
+        UIViewController *childVc = _hostController.childViewControllers[nextIndex];
+        if ([childVc isViewLoaded] && [childVc.view window]) return;
+        CGFloat childVCX = nextIndex * self.bounds.size.width;
+        childVc.view.frame = CGRectMake(childVCX, self.bounds.origin.y, self.bounds.size.width, self.bounds.size.height);
+        [self addSubview:childVc.view];
+        nextIndex = nextIndex - 2;
+    }
+}
+
 -(void)setTitlesTabItem:(MJCTabItem *)titlesTabItem
 {
     _titlesTabItem = titlesTabItem;


### PR DESCRIPTION
优化加载页面的时候会同时加载相邻的页面，防止左滑右滑的时候因为初始化的原因有闪屏出现。